### PR TITLE
Support Node auto installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 composer.phar
 composer.lock
 vendor
+site/cache
+site/themes/simple/nodejs
+site/themes/simple/node_modules
+site/themes/simple/assets/dist

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ You can easily install Flextype with Composer.
 composer create-project flextype/flextype
 ```
 
-Also you may need to install node_modules libs for default Simple Theme  
-
-```
-cd /flextype/site/themes/simple  
-npm install
-gulp
-```
-
 
 ## COMMUNITY
 Flextype is open source, community driven project, and maintained by community!

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,27 @@
         "flextype-components/registry" : "1.*",
         "flextype-components/token" : "1.*",
         "flextype-components/view" : "1.*",
-        "flextype-components/text" : "1.*"
+        "flextype-components/text" : "1.*",
+        "mouf/nodejs-installer": "^1.0"
     },
     "autoload": {
         "classmap": [
             "flextype"
+        ]
+    },
+    "extra": {
+        "mouf": {
+            "nodejs": {
+                "targetDir": "site/themes/simple/nodejs",
+                "forceLocal": false,
+                "includeBinInPath": true
+            }
+        }
+    },
+    "scripts": {
+        "post-create-project-cmd": [
+            "cd site/themes/simple && npm i",
+            "cd site/themes/simple && ./node_modules/.bin/gulp"
         ]
     }
 }

--- a/site/themes/simple/package.json
+++ b/site/themes/simple/package.json
@@ -2,14 +2,14 @@
   "name": "flextype",
   "version": "1.0.0",
   "devDependencies": {
+    "bootstrap": "^4.1.1",
     "es6-promise": "^4.2.4",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^5.0.0",
+    "gulp-concat": "^2.6.1",
     "gulp-csso": "^3.0.1",
     "gulp-sass": "^4.0.1",
-    "gulp-concat": "^2.6.1",
     "gulp-sourcemaps": "^2.6.4",
-    "bootstrap": "^4.1.1",
     "jquery": "^3.3.1"
   }
 }


### PR DESCRIPTION
I think the default theme requires one of the following options to be chosen:

- Without Node (just provide `/dist` assets), or
- Keep using Node

If using Node & NPM is the best choice, then I make this PR.

```
- Add extra to install node/npm
- Add scripts (post-create-project-cmd) to auto install npm packages and running gulp
- Remove doc npm install & gulp
- Ignore some folders
```